### PR TITLE
feat: change default asset repository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
-No changes yet.
+### Changed
+
+- Default OPRF asset repo changed from "NikolaiVChr/OpRedFlag" to "Op-RedFlag/OpRedFlag"
 
 ## [0.10] - 2024-10-14
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Create a file in your repository root called `oprf-versions.json`. The contents 
 }
 ```
 
-The keys of the JSON (in this case, "missile-code" and "damage") correspond to the ID of an OPRF asset. You can view all available options [here](https://github.com/NikolaiVChr/OpRedFlag/blob/master/versions.json).
+The keys of the JSON (in this case, "missile-code" and "damage") correspond to the ID of an OPRF asset. You can view all available options [here](https://github.com/Op-RedFlag/OpRedFlag/blob/master/versions.json).
 
 For each of those keys, you should have a version number and a file path. The file path should be set to the location of the asset file, relative to your repository's root. For now, you can leave the "version" set to null.
 
@@ -116,7 +116,7 @@ The following is an extended example with all available options.
     branch: "main"
 
     # Optional. Location of OpRedFlag asset GitHub repository, in User/Repo format
-    # Default: "NikolaiVChr/OpRedFlag"
+    # Default: "Op-RedFlag/OpRedFlag"
     repository: 'BobDotCom/OpRedFlag'
 
     # Optional. The branch of the OpRedFlag repository to use

--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ inputs:
   repository:
     description: 'Location of OpRedFlag asset GitHub repository, in User/Repo format'
     required: false
-    default: 'NikolaiVChr/OpRedFlag'
+    default: 'Op-RedFlag/OpRedFlag'
   repository-branch:
     description: 'The branch of the OpRedFlag repository to use'
     required: false


### PR DESCRIPTION
This changes the default asset repository from [NikolaiVChr/OpRedFlag](https://github.com/NikolaiVChr/OpRedFlag) to [Op-RedFlag/OpRedFlag](https://github.com/Op-RedFlag/OpRedFlag). This new repository is more up-to-date than the previous one.