### PR TITLE
docs(changelog): v0.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+No changes yet.
+
+## [0.11] - 2025-10-28
+
 ### Changed
 
 - Default OPRF asset repo changed from "NikolaiVChr/OpRedFlag" to "Op-RedFlag/OpRedFlag"
@@ -106,7 +110,8 @@ No major changes
 - Initial version
 
 
-[unreleased]: https://github.com/BobDotCom/oprf-asset-updater/compare/v0.10...HEAD
+[unreleased]: https://github.com/BobDotCom/oprf-asset-updater/compare/v0.11...HEAD
+[0.11]: https://github.com/BobDotCom/oprf-asset-updater/releases/tag/v0.11
 [0.10]: https://github.com/BobDotCom/oprf-asset-updater/releases/tag/v0.10
 [0.9.1]: https://github.com/BobDotCom/oprf-asset-updater/releases/tag/v0.9.1
 [0.9]: https://github.com/BobDotCom/oprf-asset-updater/releases/tag/v0.9

--- a/README.md
+++ b/README.md
@@ -78,14 +78,14 @@ jobs:
       contents: write
     steps:
       - name: "Manual Update"
-        uses: BobDotCom/OPRFAssetUpdater@v0.10
+        uses: BobDotCom/OPRFAssetUpdater@v0.11
         if: "${{ github.event_name == 'workflow_dispatch' }}"
         with:
           include: ${{ inputs.include }}
           exclude: ${{ inputs.exclude }}
           compatibility: ${{ inputs.compatibility }}
       - name: "Scheduled Update"
-        uses: BobDotCom/OPRFAssetUpdater@v0.10
+        uses: BobDotCom/OPRFAssetUpdater@v0.11
         if: "${{ github.event_name != 'workflow_dispatch' }}"
 
 ```
@@ -109,7 +109,7 @@ then create a manual workflow run (See [Step 4](#step-4)), and select the "major
 ## Advanced Usage
 The following is an extended example with all available options.
 ```yaml
-- uses: BobDotCom/oprf-asset-updater@v0.10
+- uses: BobDotCom/oprf-asset-updater@v0.11
   with:
     # Optional. Local branch to checkout and apply changes to
     # Default: Default branch ("")


### PR DESCRIPTION
This updates the changelog and readme from version 0.10 to version 0.11.

This is made in preparation for the v0.11 release, but shouldn't be merged until the code from the new opredflag asset repo is verified. 